### PR TITLE
fix: add homepage link to navbar title

### DIFF
--- a/src/components/ui/Header/Header.tsx
+++ b/src/components/ui/Header/Header.tsx
@@ -8,9 +8,12 @@ export default function Header() {
       <div className="container mx-auto flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8">
         {/* Logo / Site Title */}
         <div className="flex items-center gap-2">
-          <div className="text-xl font-semibold tracking-tight text-foreground">
+          <Link
+            href="/"
+            className="text-xl font-semibold tracking-tight text-foreground transition-colors hover:text-foreground/80"
+          >
             MyApp
-          </div>
+          </Link>
         </div>
 
         {/* Navigation */}


### PR DESCRIPTION
Fixes #2

Wrapped the "MyApp" navbar title in a Next.js Link component to make it clickable and navigate to the homepage.

### Changes
- Added Link wrapper around the title in Header component
- Added hover effect for better UX

Generated with [Claude Code](https://claude.ai/code)